### PR TITLE
feat: create dev branch

### DIFF
--- a/artixiso/artools-workspace/iso-profiles/build.sh
+++ b/artixiso/artools-workspace/iso-profiles/build.sh
@@ -7,36 +7,82 @@ init=runit
 #init=s6
 #init=suite66
 
+## paths
+chroot_dir="/var/lib/artools/buildiso/base/artix/rootfs"
+
+## Set color characters
+_set_color() {
+    if [ -t 1 ]; then
+        RED=$(printf '\033[31m')
+        GREEN=$(printf '\033[32m')
+        YELLOW=$(printf '\033[33m')
+        BLUE=$(printf '\033[34m')
+        BOLD=$(printf '\033[1m')
+        RESET=$(printf '\033[m')
+    else
+        RED=""
+        GREEN=""
+        YELLOW=""
+        BLUE=""
+        BOLD=""
+        RESET=""
+    fi
+}
+
+## Show an INFO message
+_msg_info() {
+    local _subject="${1}"
+    local _msg="${2}"
+    printf '%s[%s] INFO: %s\n' "${YELLOW}${BOLD}" "${_subject}" "${RESET}${BOLD}${_msg}${RESET}"
+}
+
+## Customize installation.
+_make_customize_chroot() {
+    _msg_info "Running customize_chroot.sh in '${chroot_dir}' chroot..."
+    chmod +x "${chroot_dir}/root/customize_chroot.sh"
+    artix-chroot "${chroot_dir}" "/root/customize_chroot.sh"
+    rm -f "${chroot_dir}/root/customize_chroot.sh"
+    _msg_info "Done! customize_chroot.sh run successfully..."
+}
+
+_set_color
 trap "" EXIT
 buildiso -i $init -p base -x
 
-artix-chroot /var/lib/artools/buildiso/base/artix/rootfs bash -c "pacman-key --init; pacman-key --populate artix;pacman-key --populate archlinux; pacman -Syy"
+## Update System
+_msg_info "ARTIX-CHROOT" "Live environment pacman system update & populate keyring..."
+artix-chroot ${chroot_dir} bash -c "pacman-key --init; pacman-key --populate artix;pacman-key --populate archlinux; pacman -Syy"
 
-printf "\033[1;33mAUR_BUILD:\033[0m Reading package list.\n"
+_msg_info "AUR_BUILD" "Reading package list."
 for package in $(cat ./AUR_PACKAGES | grep -vE "^#.*$")
 do
-  printf "\033[1;33mAUR_BUILD:\033[0m Cloning ${package}.\n"
-  artix-chroot /var/lib/artools/buildiso/base/artix/rootfs \
+  _msg_info "AUR_BUILD" "Cloning ${package}."
+  artix-chroot ${chroot_dir} \
 	  git clone https://aur.archlinux.org/${package}.git /etc/aur_building/$package
 done
 
-printf "\033[1;33mAUR_BUILD:\033[0m Building packages.\n"
-
-artix-chroot /var/lib/artools/buildiso/base/artix/rootfs bash -c "chmod 777 -R /etc/aur_building"
-dirs=$(artix-chroot /var/lib/artools/buildiso/base/artix/rootfs find /etc/aur_building -mindepth 1 -maxdepth 1 -type d)
+_msg_info "AUR_BUILD" "Building packages"
+artix-chroot ${chroot_dir} bash -c "chmod 777 -R /etc/aur_building"
+dirs=$(artix-chroot ${chroot_dir} find /etc/aur_building -mindepth 1 -maxdepth 1 -type d)
 for dir in $dirs
 do
-	artix-chroot /var/lib/artools/buildiso/base/artix/rootfs bash -c "cd $dir; sudo -u $non_root_user makepkg -sfci --noconfirm --needed"
+	artix-chroot ${chroot_dir} bash -c "cd $dir; sudo -u $non_root_user makepkg -sfci --noconfirm --needed"
 done
 
-if [[ $(artix-chroot /var/lib/artools/buildiso/base/artix/rootfs pacman -Qtdq) != "" ]];then
-    artix-chroot /var/lib/artools/buildiso/base/artix/rootfs \ 
+if [[ $(artix-chroot ${chroot_dir} pacman -Qtdq) != "" ]];then
+    artix-chroot ${chroot_dir} \ 
 		yes | sudo pacman -Rns $(pacman -Qtdq)
     printf "\u001b[31mPACMAN:\033[0m Orphans found and removed, exiting script.\n"
+    _msg_info "PACMAN" "Orphans found and removed, exiting script."
 else 
-    printf "\u001b[31mPACMAN:\033[0m No orphans found, exiting script.\n"
+    _msg_info "PACMAN" "No orphans found, exiting script."
 fi
 rm -rf /etc/aur_building
+
+## Check if `customize_chroot.sh` exists.
+if [[ -e $(pwd)/base/root-overlay/root/customize_chroot.sh ]]; then
+    _make_customize_chroot
+fi
 
 buildiso -i $init -p base -sc
 buildiso -i $init -p base -bc

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 sudo modprobe loop
-sudo pacman -S --noconfirm --needed artools iso-profiles
-sudo pacman -S --noconfirm --needed virtualbox virtualbox-host-dkms
-sudo modprobe vboxdrv
+
+sudo pacman -Syyu --noconfirm
+sudo pacman -S --noconfirm --needed artools iso-profiles archlinux-keyring archlinux-mirrorlist
+
+sudo pacman-key --init
+sudo pacman-key --populate
+
 ln -sf "$(pwd)/artixiso/artools-workspace" ~/
 ln -sf "$(pwd)/config/artools" ~/.config/


### PR DESCRIPTION
-  Added `archlinux-keyring` & `archlinux-mirrorlist` packages to be installed to avoid the missing mirrorlist errors when building on a freshly installed artix base system.
- Added a feature where creating a `customize_chroot.sh` under `base/root-overlay/root` directory will do various manual configurations during iso build.
- Added another feature for creating info messages when building.