### PR TITLE
feat: create docker branch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+iso
+build/
+Artix-Iso/
+pacman-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 iso
+build/
+Artix-Iso/
+pacman-cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN pacman -S --noconfirm --needed artools iso-profiles archlinux-keyring archli
 RUN pacman-key --init
 RUN pacman-key --populate
 
-WORKDIR /axyl-artix-iso
+WORKDIR /artix-iso
 COPY . .
 
 RUN mkdir -p ~/.config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Dockerfile for building the Artix ISO
+FROM angelofallaria/artix-base
+
+RUN pacman -Syyu --noconfirm
+RUN pacman -S --noconfirm --needed artools iso-profiles archlinux-keyring archlinux-mirrorlist 
+
+RUN pacman-key --init
+RUN pacman-key --populate
+
+WORKDIR /axyl-artix-iso
+COPY . .
+
+RUN mkdir -p ~/.config
+RUN ln -sf "$(pwd)/artixiso/artools-workspace" ~/
+RUN ln -sf "$(pwd)/config/artools" ~/.config/
+
+CMD cd /root/artools-workspace/iso-profiles ; ./build.sh

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
+fi
+
+## Change ownership variables.
+_user=`echo ${SUDO_USER:-$(whoami)}`
+_gid=`echo ${SUDO_GID}`
+_group=`cat /etc/group | grep ${_gid} | cut -d: -f1 | head -1`
+
+## iso Paths and file
+_build="$(pwd)/build/"
+_output="$(pwd)/Artix-Iso/"
+
+## iso filename format
+_name="artix-runit"
+_version="$(date +%Y.%m.%d)"
+_arch="x86_64"
+_iso_filename="${_name}-${_version}-${_arch}.iso"
+
+_finalize_build() {
+  local _file=$(find ${_build} -type f -name "*iso")
+
+  ## Change iso filename to current format
+  echo "+---------------------->>"
+  echo "[*] Move Iso '$(basename ${_file})' as '${_iso_filename}'..."
+  mkdir -p ${_output}
+  find ${_build} -type f -name "*.iso" -exec mv {} ${_output}${_iso_filename} \;
+
+  ## Change ownership
+  echo "+---------------------->>"
+  echo "[*] Change ${_output} ownership to '${_user}'..."
+  chown -R ${_user}:${_group} ${_output}
+
+  ## Remove empty build directory
+  rm -rf ./build
+}
+
+## Delete existing Artix-Iso directory from home user
+echo "+---------------------->>"
+echo "[*] Delete existing ${_output}..."
+if [[ -d ${_output} ]]; then
+  rm -rf ${_output}
+fi
+
+## Build Docker Image
+docker build -t artix-build ./
+
+if [ "$?" -ne 0 ]; then
+    exit 1
+fi
+
+## Run The Docker Image
+mkdir -p ${_build} ./pacman-cache
+docker run --privileged \
+           --mount type=bind,source="$(pwd)"/build,target=/root/artools-workspace/iso \
+           --mount type=bind,source="$(pwd)"/pacman-cache,target=/var/cache/pacman/pkg \
+           -t artix-build &&\
+           _finalize_build

--- a/storage-driver-setup.sh
+++ b/storage-driver-setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
+fi
+
+_file="/etc/docker/daemon.json"
+_service="docker.service"
+
+## Stop Docker Service
+if [[ $(systemctl is-active ${_service}) == "active" ]]; then
+    systemctl stop ${_service}
+fi
+
+## Create daemon.json file along with the following lines.
+if [[ ! -f ${_file} ]]; then
+    echo "{
+  \"storage-driver\": \"vfs\"
+}" > ${_file}
+fi
+
+## Start Docker Service
+systemctl start ${_service}


### PR DESCRIPTION
- Added `Dockerfile` and automation script: `docker-build.sh` to build artix iso without being in an Artix machine/VM. Very helpful for those who are currently migrating their Arch Linux distro to Artix.
- Added `storage-driver-setup.sh` script to avoid **wrong filesystem** error and overall conflict with the build.